### PR TITLE
Add HTML renderer and Narendra Modi example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ If the CLI has issues, you can generate HTML previews directly with Python:
 
 ```python
 import json
-from onepage.renderers.html import HTMLRenderer
-from onepage.core.models import IntermediateRepresentation
+from onepage.render import HTMLRenderer
+from onepage.models import IntermediateRepresentation
 
 # Load or create IR data
 with open('./out/Q1058/onepage.ir.json', 'r') as f:

--- a/examples/simple_merge.py
+++ b/examples/simple_merge.py
@@ -6,8 +6,8 @@ from onepage.render import WikitextRenderer
 
 
 def main():
-    qid = "Q42"  # Douglas Adams
-    languages = ["en", "de"]
+    qid = "Q1058"  # Narendra Modi
+    languages = ["en", "hi"]
 
     # This call requires network access to the Wikimedia APIs.
     ir = merge_article(qid, languages)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,18 @@
+import pytest
+
+from onepage.models import Entity, Claim, Section, IntermediateRepresentation
+from onepage.render import HTMLRenderer
+
+
+def test_html_renderer_basic():
+    entity = Entity(qid="Q1058", labels={"en": "Narendra Modi"})
+    claim = Claim(id="c1", text="Narendra Modi is the Prime Minister of India.")
+    section = Section(id="lead", items=["c1"])
+    ir = IntermediateRepresentation(entity=entity, sections=[section], content={"c1": claim})
+
+    renderer = HTMLRenderer("en")
+    html = renderer.render(ir)
+
+    assert "<html>" in html
+    assert "<h1>Narendra Modi</h1>" in html
+    assert "Narendra Modi is the Prime Minister of India." in html


### PR DESCRIPTION
## Summary
- support HTML output via new `HTMLRenderer`
- document manual HTML preview generation and update example to Q1058 (Narendra Modi)
- add tests for HTML rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58061a614832fbfcbcc289f5e725b