### PR TITLE
Fix image extraction using wikilinks

### DIFF
--- a/onepage/parse.py
+++ b/onepage/parse.py
@@ -29,12 +29,18 @@ def parse_wikitext(wikitext: str) -> ParsedArticle:
 
     parsed = wtp.parse(wikitext)
 
-    # Extract images from ``[[File:..]]`` links and ensure uniqueness
+    # Extract images from ``[[File:..]]`` or ``[[Image:..]]`` links and ensure
+    # uniqueness. ``wikitextparser`` exposes these as regular wikilinks, so we
+    # filter by the link title prefix.
     images: List[str] = []
-    for image in parsed.images:
-        title = image.title.strip()
-        if title not in images:
-            images.append(title)
+    seen = set()
+    for link in parsed.wikilinks:
+        title = link.title.strip()
+        if title.lower().startswith(("file:", "image:")):
+            key = title.lower()
+            if key not in seen:
+                images.append(title)
+                seen.add(key)
 
     # Extract the first infobox template, keeping simple key/value pairs
     infobox: Dict[str, str] = {}

--- a/onepage/translate.py
+++ b/onepage/translate.py
@@ -180,12 +180,16 @@ class TextCleaner:
         """Extract plain text from wikitext, removing all markup."""
         parsed = wtp.parse(wikitext)
         
-        # Remove templates
-        for template in parsed.templates:
+        # Remove templates starting from the end so index positions remain
+        # valid for earlier entries. ``wikitextparser`` objects become
+        # "dead" when text before them is mutated, so iterating in reverse
+        # avoids ``DeadIndexError`` when stripping multiple templates.
+        for template in parsed.templates[::-1]:
             template.string = ""
-        
-        # Remove references
-        for tag in parsed.get_tags():
+
+        # Remove references using the same reverse-iteration strategy to
+        # prevent index invalidation after previous mutations.
+        for tag in parsed.get_tags()[::-1]:
             if tag.name and tag.name.lower() in ["ref", "references"]:
                 tag.string = ""
         


### PR DESCRIPTION
## Summary
- parse images from wikitext using wikilinks and ensure case-insensitive uniqueness
- avoid DeadIndexError in `TextCleaner.extract_plain_text` by removing templates and references in reverse

## Testing
- `pytest -q`
- `python - <<'PY'
from onepage.merge import merge_article
from onepage.render import HTMLRenderer
ir = merge_article("Q1058", ["en", "hi"], target_lang="en")
HTMLRenderer("en").render(ir)
PY` *(fails: ProxyError: Unable to connect to proxy, Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b587ad9d24832fa6c967c7c4e7744f