### PR TITLE
fix: handle template removal safely

### DIFF
--- a/onepage/translate.py
+++ b/onepage/translate.py
@@ -181,14 +181,15 @@ class TextCleaner:
         parsed = wtp.parse(wikitext)
         
         # Remove templates
-        # Modifying the parsed tree invalidates internal indices for
-        # subsequent elements. Iterate in reverse order so earlier
-        # indices remain valid when later elements are removed.
-        for template in reversed(parsed.templates):
+        # ``wikitextparser`` invalidates indices of later nodes when earlier
+        # ones are mutated.  Iterate over copies of the template/tag lists so
+        # that we can safely mutate the original parse tree without hitting
+        # ``DeadIndexError``.
+        for template in reversed(list(parsed.templates)):
             template.string = ""
 
         # Remove references
-        for tag in reversed(parsed.get_tags()):
+        for tag in reversed(list(parsed.get_tags())):
             if tag.name and tag.name.lower() in ["ref", "references"]:
                 tag.string = ""
         

--- a/tests/test_text_cleaner.py
+++ b/tests/test_text_cleaner.py
@@ -1,0 +1,8 @@
+import pytest
+from onepage.translate import TextCleaner
+
+
+def test_extract_plain_text_handles_templates_and_refs():
+    wikitext = "Start {{temp|1}} middle {{temp2|a=b}} end <ref>ref</ref>"
+    cleaned = TextCleaner.extract_plain_text(wikitext)
+    assert cleaned == "Start middle end"


### PR DESCRIPTION
## Summary
- avoid `DeadIndexError` in `TextCleaner.extract_plain_text` by iterating over copies of templates and tags
- add regression test covering templates and reference removal

## Testing
- `pytest`
- `python - <<'PY'
from onepage.merge import merge_article
from onepage.render import HTMLRenderer
import os

# Fetch English and Hindi articles for Q1058 and merge them
ir = merge_article("Q1058", ["en", "hi"], target_lang="en")

# Render the merged IR to HTML
html = HTMLRenderer("en").render(ir)

# Save the preview
os.makedirs("./out/Q1058", exist_ok=True)
with open("./out/Q1058/preview.en.html", "w") as f:
    f.write(html)
print('done')
PY` *(fails: HTTPSConnectionPool(host='www.wikidata.org', port=443): Max retries exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b58e260954832f83b4ee5fedf5d201