### PR TITLE
docs: create output dir for preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If the CLI has issues, you can generate HTML previews directly with Python:
 
 ```python
 import json
+import os
 from onepage.render import HTMLRenderer
 from onepage.models import IntermediateRepresentation
 
@@ -78,6 +79,8 @@ ir = IntermediateRepresentation.from_dict(ir_data)
 renderer = HTMLRenderer('en')
 html_content = renderer.render(ir)
 
+# Ensure output directory exists before writing the preview
+os.makedirs('./out/Q1058', exist_ok=True)
 with open('./out/Q1058/preview.en.html', 'w') as f:
     f.write(html_content)
 ```


### PR DESCRIPTION
## Summary
- ensure manual preview code snippet creates output directory before writing HTML preview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b58ff97ee8832f9adb1d278031efb4