### PR TITLE
Translate merged text and style HTML output

### DIFF
--- a/onepage/merge.py
+++ b/onepage/merge.py
@@ -78,8 +78,14 @@ class TextMerger:
                     heading_norm = "Other"
 
                 sentences = [
-                    s.strip() for s in re.split(r"(?<=[.!?]) +", clean_text) if s.strip()
+                    TextCleaner.clean_sentence(s)
+                    for s in re.split(r"(?<=[.!?]) +", clean_text)
+                    if s.strip()
                 ]
+
+                if lang != target_lang:
+                    translations = translator.batch_translate(sentences, lang)
+                    sentences = [TextCleaner.clean_sentence(t[0]) for t in translations]
 
                 for sentence in sentences:
                     if sentence not in grouped[heading_norm]:

--- a/onepage/render.py
+++ b/onepage/render.py
@@ -274,10 +274,22 @@ class HTMLRenderer:
 
     def render(self, ir: IntermediateRepresentation) -> str:
         """Render the IR to a basic HTML document."""
-        parts = ["<html>", "<body>"]
-
         title = ir.entity.labels.get(self.language, ir.entity.qid)
-        parts.append(f"<h1>{title}</h1>")
+        parts = [
+            "<html>",
+            "<head>",
+            "<meta charset=\"utf-8\"/>",
+            f"<title>{title}</title>",
+            "<link rel=\"stylesheet\" href=\"https://en.wikipedia.org/w/load.php?modules=skins.vector.styles.legacy&only=styles\"/>",
+            "</head>",
+            "<body class=\"mw-body\">",
+            f"<h1 id=\"firstHeading\">{title}</h1>",
+            "<div class=\"mw-parser-output\">",
+        ]
+
+        infobox_html = self._render_infobox(ir)
+        if infobox_html:
+            parts.append(infobox_html)
 
         lead = self._find_section_by_id(ir.sections, "lead")
         if lead:
@@ -291,7 +303,7 @@ class HTMLRenderer:
                 if section_html:
                     parts.append(section_html)
 
-        parts.extend(["</body>", "</html>"])
+        parts.extend(["</div>", "</body>", "</html>"])
         return "\n".join(parts)
 
     def _render_section(self, section: Section, ir: IntermediateRepresentation) -> str:
@@ -324,3 +336,12 @@ class HTMLRenderer:
             if section.id == section_id:
                 return section
         return None
+
+    def _render_infobox(self, ir: IntermediateRepresentation) -> str:
+        box = ir.metadata.get("infobox")
+        if not box:
+            return ""
+        rows = []
+        for key, values in box.items():
+            rows.append(f"<tr><th>{key}</th><td>{', '.join(values)}</td></tr>")
+        return "<table class=\"infobox\">" + "".join(rows) + "</table>"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -14,5 +14,5 @@ def test_html_renderer_basic():
     html = renderer.render(ir)
 
     assert "<html>" in html
-    assert "<h1>Narendra Modi</h1>" in html
     assert "Narendra Modi is the Prime Minister of India." in html
+    assert "<h1" in html and "Narendra Modi</h1>" in html


### PR DESCRIPTION
## Summary
- translate non-English sentences to English during merge
- render basic Wikipedia-style HTML with stylesheet and infobox table

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b592295f18832fb74dbaca73bd7d9e