### PR TITLE
Use LibreTranslate and display references in HTML previews

### DIFF
--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,6 +1,6 @@
 import pytest
 
-from onepage.models import Entity, Claim, Section, IntermediateRepresentation
+from onepage.models import Entity, Claim, Section, IntermediateRepresentation, Reference
 from onepage.render import HTMLRenderer
 
 
@@ -16,3 +16,23 @@ def test_html_renderer_basic():
     assert "<html>" in html
     assert "Narendra Modi is the Prime Minister of India." in html
     assert "<h1" in html and "Narendra Modi</h1>" in html
+
+
+def test_html_renderer_references():
+    entity = Entity(qid="Q1", labels={"en": "Test"})
+    claim = Claim(id="c1", text="Statement.", sources=["r1"])
+    section = Section(id="lead", items=["c1"])
+    ref = Reference(id="r1", title="Example", url="https://example.com", author="Author", date="2020")
+    ir = IntermediateRepresentation(
+        entity=entity,
+        sections=[section],
+        content={"c1": claim},
+        references={"r1": ref},
+    )
+
+    renderer = HTMLRenderer("en")
+    html = renderer.render(ir)
+
+    assert "[1]" in html
+    assert "<ol class=\"references\">" in html
+    assert "https://example.com" in html


### PR DESCRIPTION
## Summary
- Switch translation to LibreTranslate with Google fallback to avoid MyMemory rate limits
- Render HTML with Wikipedia styling and numbered citation list
- Test HTML renderer for reference rendering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b597b61c4c832fab147cb14913ddd9