### PR TITLE
Handle invalid JSON from translation services

### DIFF
--- a/onepage/translate.py
+++ b/onepage/translate.py
@@ -115,7 +115,14 @@ class TranslationService:
                 return f"[TRANSLATION UNAVAILABLE FROM {source.upper()}]"
             response.raise_for_status()
 
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError:
+                # Service returned an empty or non-JSON response
+                print("Translation failed: invalid JSON from LibreTranslate")
+                self.last_request_time = time.time()
+                return f"[TRANSLATION UNAVAILABLE FROM {source.upper()}]"
+
             if "translatedText" in data:
                 translated = data["translatedText"]
                 self.last_request_time = time.time()
@@ -155,7 +162,12 @@ class TranslationService:
             }
             response = self.session.get(url, params=params, timeout=10)
             response.raise_for_status()
-            data = response.json()
+            try:
+                data = response.json()
+            except ValueError:
+                print("Google translation failed: invalid JSON response")
+                self.last_request_time = time.time()
+                return None
             translated = "".join(segment[0] for segment in data[0])
             self.last_request_time = time.time()
             return translated


### PR DESCRIPTION
## Summary
- gracefully handle non-JSON responses from LibreTranslate
- guard Google fallback against invalid JSON responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b599152138832fabacafd69e076b9c