### PR TITLE
Add tests for CLI, parsing, and translation fallback

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,29 @@
+"""Tests for the command line interface."""
+
+from click.testing import CliRunner
+
+from onepage.cli import cli
+
+
+def test_fetch_command(monkeypatch, tmp_path):
+    """Fetch command should invoke ArticleFetcher and output messages."""
+    captured = {}
+
+    class DummyFetcher:
+        def fetch_all(self, qid, languages, out):
+            captured["args"] = (qid, languages, out)
+
+    # Replace ArticleFetcher with dummy implementation
+    monkeypatch.setattr("onepage.cli.ArticleFetcher", DummyFetcher)
+
+    runner = CliRunner()
+    out_dir = tmp_path / "data"
+    result = runner.invoke(
+        cli,
+        ["fetch", "--qid", "Q1", "--languages", "en,hi", "--out", str(out_dir)],
+    )
+
+    assert result.exit_code == 0
+    assert "Fetching articles for Q1 in languages: en, hi" in result.output
+    assert "Results written to" in result.output
+    assert captured["args"] == ("Q1", ["en", "hi"], str(out_dir))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,33 @@
+"""Tests for wikitext parsing utilities."""
+
+from onepage.parse import parse_wikitext
+
+
+def test_parse_wikitext_basic():
+    """Parse sample wikitext into structured components."""
+    wikitext = """
+Lead.
+
+{{Infobox person
+| name = Jane Doe
+| occupation = Tester
+}}
+== Biography ==
+Some content with an [[File:Example.jpg|thumb]] image.
+<ref>Example reference</ref>
+"""
+
+    parsed = parse_wikitext(wikitext)
+
+    # Sections should include lead and Biography
+    assert parsed.sections["lead"].startswith("Lead.")
+    assert "Biography" in parsed.sections
+
+    # Image links should be captured
+    assert parsed.images == ["File:Example.jpg"]
+
+    # Infobox values should be parsed
+    assert parsed.infobox["name"] == "Jane Doe"
+
+    # References should be collected
+    assert "Example reference" in parsed.references

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,0 +1,51 @@
+"""Tests for translation service error handling and fallback."""
+
+from onepage.translate import TranslationService
+
+
+def test_libretranslate_invalid_json(monkeypatch, capsys):
+    """LibreTranslate failure should return placeholder and log error."""
+    service = TranslationService()
+
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            raise ValueError("invalid JSON")
+
+    def fake_post(url, data, timeout):
+        return FakeResponse()
+
+    # Ensure no actual HTTP request is made
+    monkeypatch.setattr(service.session, "post", fake_post)
+
+    result = service._translate_via_libre("Bonjour", "fr", "en")
+    captured = capsys.readouterr()
+
+    assert result == "[TRANSLATION UNAVAILABLE FROM FR]"
+    assert "Translation failed" in captured.out
+
+
+def test_translate_to_english_falls_back(monkeypatch):
+    """Fallback to Google translation when LibreTranslate fails."""
+    service = TranslationService()
+
+    def fake_libre(text, source, target):
+        return "[TRANSLATION UNAVAILABLE FROM FR]"
+
+    def fake_google(text, source, target):
+        assert text == "Bonjour"
+        assert source == "fr"
+        assert target == "en"
+        return "Hello"
+
+    monkeypatch.setattr(service, "_translate_via_libre", fake_libre)
+    monkeypatch.setattr(service, "_translate_via_google", fake_google)
+
+    translated, confidence = service.translate_to_english("Bonjour", "fr")
+
+    assert translated == "Hello"
+    assert confidence > 0


### PR DESCRIPTION
## Summary
- add CLI test ensuring `fetch` invokes `ArticleFetcher` and emits expected output
- add parser test verifying sections, images, infobox, and references are extracted from wikitext
- add translation tests verifying LibreTranslate JSON failures log a message and trigger Google fallback
- patch CLI test to replace `ArticleFetcher` with `DummyFetcher` class directly per review feedback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b599d3ffe4832f817174ee4139915b